### PR TITLE
fix: use big number for weighted pool info

### DIFF
--- a/src/types/MultiRouterTypes.ts
+++ b/src/types/MultiRouterTypes.ts
@@ -87,8 +87,8 @@ export class HybridPool extends Pool {
 type WeightedPoolInfo = PoolInfoNoType & { weight0: number; weight1: number }
 
 export class WeightedPool extends Pool {
-  weight0: number
-  weight1: number
+  weight0: BigNumber
+  weight1: BigNumber
   constructor(info: WeightedPoolInfo) {
     super({
       type: PoolType.Weighted,


### PR DESCRIPTION
currently the class WeightedPool uses number. This max weight a weighted pool can have exceeds the max value a javascript number type can hold. 