### PR TITLE
feat: adding serialize method to CurrencyAmount

### DIFF
--- a/src/entities/AbstractCurrency.test.ts
+++ b/src/entities/AbstractCurrency.test.ts
@@ -1,0 +1,30 @@
+import { Token } from './Token'
+import { NativeCurrency } from '../entities/NativeCurrency'
+import { Currency } from '../entities/Currency'
+import { ChainId } from '../enums'
+
+describe('AbstractCurrency', () => {
+  const ADDRESS_ONE = '0x0000000000000000000000000000000000000001'
+
+  describe('#serialize', () => {
+    it('renders string of address for Token', () => {
+      const token = new Token(1, ADDRESS_ONE, 3)
+      expect(token.serialize()).toEqual(ADDRESS_ONE)
+    })
+
+    it('renders string of address for NativeCurrency', () => {
+      class MoonBeam extends NativeCurrency {
+        constructor(chainId: number) {
+          super(chainId, 18)
+        }
+        equals(other: Currency): boolean {
+          return other.isNative && other.chainId === this.chainId
+        }
+        get wrapped(): Token {
+          return new Token(ChainId.MAINNET, ADDRESS_ONE, 18)
+        }
+      }
+      expect(new MoonBeam(ChainId.MAINNET).serialize()).toEqual(ADDRESS_ONE)
+    })
+  })
+})

--- a/src/entities/AbstractCurrency.ts
+++ b/src/entities/AbstractCurrency.ts
@@ -60,4 +60,11 @@ export abstract class AbstractCurrency {
    * implement this to be used in Uniswap
    */
   public abstract get wrapped(): Token
+
+  /**
+   * Returns token address. Useful in cases where a dependency is needed to detect changes (e.g. useEffect).
+   */
+  public serialize(): string {
+    return this.wrapped.address
+  }
 }

--- a/src/entities/CurrencyAmount.test.ts
+++ b/src/entities/CurrencyAmount.test.ts
@@ -4,6 +4,9 @@ import JSBI from 'jsbi'
 import { MaxUint256 } from '../constants'
 import { Percent } from './Percent'
 import { Token } from './Token'
+import { NativeCurrency } from './NativeCurrency'
+import { Currency } from './Currency'
+import { ChainId } from '../enums'
 
 describe('CurrencyAmount', () => {
   const ADDRESS_ONE = '0x0000000000000000000000000000000000000001'
@@ -110,6 +113,30 @@ describe('CurrencyAmount', () => {
       const token = new Token(1, ADDRESS_ONE, 18)
       const amount = CurrencyAmount.fromRawAmount(token, 123e13)
       expect(amount.toExact()).toEqual('0.00123')
+    })
+  })
+
+  describe('#serialize', () => {
+    it('renders string with address and amount for Token', () => {
+      const token = new Token(1, ADDRESS_ONE, 3, 'MOONBEAM')
+      const amount = CurrencyAmount.fromRawAmount(token, 123456)
+      expect(amount.serialize()).toEqual(`[${ADDRESS_ONE} - 123.456]`)
+    })
+
+    it('renders string with address and amount for NativeCurrency', () => {
+      class MoonBeam extends NativeCurrency {
+        constructor(chainId: number) {
+          super(chainId, 18)
+        }
+        equals(other: Currency): boolean {
+          return other.isNative && other.chainId === this.chainId
+        }
+        get wrapped(): Token {
+          return new Token(ChainId.MAINNET, ADDRESS_ONE, 18)
+        }
+      }
+      const amount = CurrencyAmount.fromRawAmount(new MoonBeam(ChainId.MAINNET), 4234)
+      expect(amount.serialize()).toEqual(`[${ADDRESS_ONE} - 0.000000000000004234]`)
     })
   })
 })

--- a/src/entities/CurrencyAmount.ts
+++ b/src/entities/CurrencyAmount.ts
@@ -95,4 +95,13 @@ export class CurrencyAmount<T extends Currency> extends Fraction {
     if (this.currency.isToken) return this as CurrencyAmount<Token>
     return CurrencyAmount.fromFractionalAmount(this.currency.wrapped, this.numerator, this.denominator)
   }
+
+  /**
+   * Returns a string representation of the address and currency amount.
+   * Useful in cases where a dependency is needed to detect changes (e.g. useEffect).
+   * @return string [0x6B3595068778DD592e39A122f4f5a5cF09C90fE2 - 1323.94]
+   */
+  public serialize(): string {
+    return `[${this.currency.wrapped.address} - ${this.toExact()}]`
+  }
 }


### PR DESCRIPTION
Related to: https://github.com/sushiswap/sushiswap-interface/pull/339

Adding a serialize method on CurrencyAmount & Currency so it's more efficient to detect changes for components using useEffect.

Will display like `[0x6B3595068778DD592e39A122f4f5a5cF09C90fE2 - 1323.34223]` 